### PR TITLE
当不指定图片时，让字母头像垂直居中

### DIFF
--- a/docs/.vuepress/components/ChatMessage.vue
+++ b/docs/.vuepress/components/ChatMessage.vue
@@ -56,7 +56,7 @@ export default {
 .avatar-text {
   background: var(--c-bg);
   text-align: center;
-  line-height: 40px;
+  line-height: 36px;
   font-size: 24px;
   font-weight: 600;
 }


### PR DESCRIPTION
原来是居中的，上次调整头像大小，忘了改字母的 `line-height` ，导致它偏下了