### PR TITLE
修改了editlink,并删除了多余的sidebar标题

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -23,7 +23,7 @@ export default defineConfig({
     nav: nav(), // @ts-ignore
     sidebar: sidebarGuide(),
     editLink: {
-      pattern: 'https://github.com/GraiaCommunity/Docs/edit/main/docs/:path',
+      pattern: 'https://github.com/GraiaCommunity/Docs/edit/vitepress/docs/:path',
       text: '在 GitHub 上编辑此页',
     },
     socialLinks: [
@@ -85,9 +85,8 @@ function sidebarGuide() {
         },
         { text: '好大的奶', link: '/guide/forward_message' },
         { text: '来点网上的涩图', link: '/guide/image_from_internet' },
-        { text: '来点 xxx 涩图', link: '/guide/message_parser/' },
         {
-          text: '来点 xxx 涩图',
+          text: '来点 xxx 涩图', link: '/guide/message_parser/',
           items: [
             { text: '消息链匹配器', link: '/guide/message_parser/base_parser' },
             { text: 'Twilight', link: '/guide/message_parser/twilight' },

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -86,7 +86,8 @@ function sidebarGuide() {
         { text: '好大的奶', link: '/guide/forward_message' },
         { text: '来点网上的涩图', link: '/guide/image_from_internet' },
         {
-          text: '来点 xxx 涩图', link: '/guide/message_parser/',
+          text: '来点 xxx 涩图',
+          link: '/guide/message_parser/',
           items: [
             { text: '消息链匹配器', link: '/guide/message_parser/base_parser' },
             { text: 'Twilight', link: '/guide/message_parser/twilight' },


### PR DESCRIPTION
文档sidebar中存在重复标题“来点 xxx 涩图。
当前页面左下角的"[在 GitHub 上编辑此页]"无法导向正确的Github分支。