### PR TITLE
移除不再维护的及不建议参考其核心架构的 Bot，更新 Bot 信息，添加基础标准

### DIFF
--- a/docs/appendix/awesome_bot.md
+++ b/docs/appendix/awesome_bot.md
@@ -4,17 +4,21 @@
 假设你想要把你的仓库也写在这了，欢迎 PR  
 （以下仓库排名不分先后）
 
-更多请查看 [Awesome Graia](https://github.com/GraiaCommunity/Docs/issues/30)
+列在此处 Bot 的基本标准：
+
+- 使用 `pyproject.toml` 作为项目依赖及元数据存储文件
+- 使用 `Saya` 作为模块管理工具
+- 代码使用 `isort` `black` 等格式化工具
+- 代码风格基本符合 `PEP 8` 建议
+- 核心功能均可在本地部署
 :::
 
 <div class="bot-repo">
-  <GitRepo user="djkcyl" repo="ABot-Graia" archived><b>已停更 最后一次更新在2022.05.23</b><br />一个使用 Graia Ariadne 搭建的 QQ 功能性机器人。</GitRepo>
   <GitRepo user="djkcyl" repo="BBot-Graia"><b>Abot正统在Bbot</b><br />一个使用 gRPC 接口用于 QQ 群内高效推送 BiliBili 动态和直播的机器人</GitRepo>
   <GitRepo user="I-love-study" repo="A_Simple_QQ_Bot">一个普普通通的 QQ 机器人</GitRepo>
   <GitRepo user="Redlnn" repo="redbot">一个以 Graia Ariadne 框架为基础的 QQ 机器人</GitRepo>
   <GitRepo user="SAGIRI-kawaii" repo="sagiri-bot">基于Graia和Mirai的QQ机器人 SAGIRI-BOT</GitRepo>
-  <GitRepo user="BlueGlassBlock" repo="Xenon">An elegant QQ bot based on Mirai and Graia Project.</GitRepo>
-  <GitRepo user="MadokaProject" repo="Madoka">一个可自定义的，基于Graia和Mirai的集群管、功能、娱乐为一体的QQ插件式机器人</GitRepo>
+  <GitRepo user="BlueGlassBlock" repo="NeNeRobo">服务于 Graia Community 的项目管理，GitHub 自动化 Bot</GitRepo>
   <GitRepo user="zzzzz167" repo="Yuki" archived><b><s>已停更</s>哦我的上帝，ta又更新了</b><br />No Description</GitRepo>
   <GitRepo user="RF-Tar-Railt" repo="RaianBot">一个基于 Ariadne 与 Alconna 的简易 QQ 机器人</GitRepo>
   <GitRepo user="AwordaProject" repo="Aworda-LBot">霖念的小世界</GitRepo>

--- a/docs/appendix/awesome_bot.md
+++ b/docs/appendix/awesome_bot.md
@@ -4,13 +4,14 @@
 假设你想要把你的仓库也写在这了，欢迎 PR  
 （以下仓库排名不分先后）
 
-列在此处 Bot 的基本标准：
+列在此处的 Bot 所需要达到的基本标准：
 
 - 使用 `pyproject.toml` 作为项目依赖及元数据存储文件
-- 使用 `Saya` 作为模块管理工具
-- 代码使用 `isort` `black` 等格式化工具
-- 代码风格基本符合 `PEP 8` 建议
+- 使用 [**Saya**](https://github.com/GraiaProject/Saya) 作为模块管理工具
+- 代码使用 [**isort**](https://pycqa.github.io/isort/)、[**Black**](https://github.com/psf/black) 等格式化工具
+- 代码风格基本符合 **PEP 8** 建议
 - 核心功能均可在本地部署
+
 :::
 
 <div class="bot-repo">


### PR DESCRIPTION
# Check List

## 假设修改的是 Markdown

- [x] 是否有遵守[中文文案排版指南](https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.zh-Hans.md)
- [x] 是否有遵守[Markdownlint 排版规则](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md)

## 你添加/修改/删除了啥

- 移除 `ABot` 与 `Xenon` ：不再受到维护
- 移除 `Madoka`：其核心架构不适合社区参考
- 增加 `NeNeRobo`：服务于 Graia Community 的项目管理，GitHub 自动化 Bot
- 提示列出 Bot 的基本标准