### PR TITLE
Fix:在 GitHub 上编辑此页面 指向的链接有误

### DIFF
--- a/docs/.vitepress/config/index.mts
+++ b/docs/.vitepress/config/index.mts
@@ -27,7 +27,7 @@ export default defineConfig({
     nav,
     sidebar,
     editLink: {
-      pattern: 'https://github.com/GraiaCommunity/Docs/edit/remake/docs/:path',
+      pattern: 'https://github.com/GraiaCommunity/Docs/edit/vitepress/docs/:path',
       text: '在 GitHub 上编辑此页'
     },
     socialLinks: [{ icon: 'github', link: 'https://github.com/GraiaCommunity/Docs' }],


### PR DESCRIPTION
# Check List

## 假设修改的是 Markdown

<!--如果有没遵守的，可以在下面写一下为什么哦-->

- [x] 是否有遵守[中文文案排版指南](https://github.com/sparanoid/chinese-copywriting-guidelines/blob/master/README.zh-Hans.md)
- [x] 是否有遵守[Markdownlint 排版规则](https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md)

## 你添加/修改/删除了啥

将 `在 GitHub 上编辑此页面` 更改为正确的链接
